### PR TITLE
Patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Monero TypeScript Library
 
-A TypeScript library for creating Monero applications using RPC and WebAssembly bindings to [monero v0.18.2.2 'Flourine Fermie'](https://github.com/monero-project/monero/tree/v0.18.2.2).
+A TypeScript library for creating Monero applications using RPC and WebAssembly bindings to [monero v0.18.2.2 'Flourine Fermi'](https://github.com/monero-project/monero/tree/v0.18.2.2).
 
 * Supports client-side wallets in Node.js and the browser using WebAssembly.
 * Supports wallet and daemon RPC clients.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Monero TypeScript Library
 
-A TypeScript library for creating Monero applications using RPC and WebAssembly bindings to [monero v0.18.2.2 'Flourine Fermi'](https://github.com/monero-project/monero/tree/v0.18.2.2).
+A TypeScript library for creating Monero applications using RPC and WebAssembly bindings to [monero v0.18.2.2 'Fluorine Fermi'](https://github.com/monero-project/monero/tree/v0.18.2.2).
 
 * Supports client-side wallets in Node.js and the browser using WebAssembly.
 * Supports wallet and daemon RPC clients.


### PR DESCRIPTION
Fix typo in Monero release name. Should be Fluorine Fermi not Flourine Fermie.

https://www.getmonero.org/downloads/