### PR TITLE
add scripts windows-compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
         "querystring-es3": "^0.2.1",
+        "shx": "^0.3.4",
         "stream-browserify": "^3.0.0",
         "stream-http": "^3.2.0",
         "ts-loader": "^9.4.4",
@@ -7305,6 +7306,44 @@
         "node": ">=8"
       }
     },
+    "node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/shelljs/node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/shelljs/node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/shiki": {
       "version": "0.14.4",
       "dev": true,
@@ -7314,6 +7353,22 @@
         "jsonc-parser": "^3.2.0",
         "vscode-oniguruma": "^1.7.0",
         "vscode-textmate": "^8.0.0"
+      }
+    },
+    "node_modules/shx": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.3",
+        "shelljs": "^0.8.5"
+      },
+      "bin": {
+        "shx": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/side-channel": {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "start": "todo",
     "build_web_worker": "webpack --config ./webpack.worker.js",
     "build_web_tests": "webpack --config ./webpack.tests.js",
-    "test": "npm run build_commonjs && node --enable-source-maps --no-experimental-fetch --experimental-wasm-threads node_modules/mocha/bin/_mocha --require @babel/register 'dist/src/test/TestAll' --timeout 900000000 --exit",
+    "test": "npm run build_commonjs && node --enable-source-maps --no-experimental-fetch --experimental-wasm-threads node_modules/mocha/bin/_mocha --require @babel/register \"dist/src/test/TestAll\" --timeout 900000000 --exit",
     "typedoc": "typedoc ./index.ts --out ./docs/typedocs --excludePrivate --disableSources",
-    "build_commonjs": "babel ./src  --extensions '.js,.ts' --out-dir ./dist/src && babel ./index.ts  --extensions '.ts' --out-dir ./dist && mkdir -p dist/dist && cp dist/monero_wallet_full.js dist/monero_wallet_keys.js dist/dist && cp dist/*.js.map dist/dist && cp dist/*.wasm dist/dist",
+    "build_commonjs": "babel ./src  --extensions \".js,.ts\" --out-dir ./dist/src && babel ./index.ts  --extensions \".ts\" --out-dir ./dist && shx mkdir -p dist/dist && shx cp dist/monero_wallet_full.js dist/monero_wallet_keys.js dist/dist && shx cp dist/*.js.map dist/dist && shx cp dist/*.wasm dist/dist",
     "check_babel_version": "babel -V"
   },
   "build": {
@@ -74,6 +74,7 @@
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
     "querystring-es3": "^0.2.1",
+    "shx": "^0.3.4",
     "stream-browserify": "^3.0.0",
     "stream-http": "^3.2.0",
     "ts-loader": "^9.4.4",


### PR DESCRIPTION
### Issue
`package.json` scripts `build_commonjs` and `test` fail on Windows platform:
```
> monero-ts@0.9.4 build_commonjs
> babel ./src  --extensions '.js,.ts' --out-dir ./dist/src && babel ./index.ts  --extensions '.ts' --out-dir ./dist && mkdir -p dist/dist && cp dist/monero_wallet_full.js dist/monero_wallet_keys.js dist/dist && cp dist/*.js.map dist/dist && cp dist/*.wasm dist/dist

Successfully compiled 0 files with Babel (14ms).
Successfully compiled 0 files with Babel (1ms).
The syntax of the command is incorrect.

Process finished with exit code 1
```

The issue occurs because:
* single quotes (`'`) are not properly recognized on windows platforms.
* `cp` command is not a valid Windows command.



### Implemented solution
* Replace single quotes (`'`) with escaped double quotes (`\"`).
   This tells the JSON parser that the double quotes are part of the string value itself and not the JSON syntax.
* Make use of `shx` package, a cross-platform support for Unix-like commands. 
  `shx` is installed as dev-dependency.

```
> monero-ts@0.9.4 build_commonjs
> babel ./src  --extensions ".js,.ts" --out-dir ./dist/src && babel ./index.ts  --extensions ".ts" --out-dir ./dist && shx mkdir -p dist/dist && shx cp dist/monero_wallet_full.js dist/monero_wallet_keys.js dist/dist && shx cp dist/*.js.map dist/dist && shx cp dist/*.wasm dist/dist

Successfully compiled 94 files with Babel (2498ms).
Successfully compiled 1 file with Babel (399ms).

Process finished with exit code 0
```